### PR TITLE
Add Information Hub link from home page

### DIFF
--- a/Information-Hub/index.html
+++ b/Information-Hub/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Information Hub</title>
+  <link rel="stylesheet" href="../assets/index-Dt01Vk_F.css">
+</head>
+<body class="p-4">
+  <h1>Information Hub</h1>
+  <p>Select a resource below:</p>
+  <ul>
+    <li><a href="Israel-Palestine-Conflict/Historical-Timeline.md">Israel-Palestine Conflict Historical Timeline</a></li>
+  </ul>
+  <p><a href="../index.html">Back to Home</a></p>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
     <link rel="stylesheet" crossorigin href="/assets/index-Dt01Vk_F.css">
   </head>
   <body>
+    <header>
+      <nav>
+        <a href="/Information-Hub/">Information Hub</a>
+      </nav>
+    </header>
     <div id="root"></div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add navigation link to Information Hub on the home page
- create simple Information Hub landing page

## Testing
- `npm install` *(in `webapp`)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_687a00b22f54832da8f36dd24ce58e90